### PR TITLE
add preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,12 @@
     </div>
 
     <div class="d-flex align-items-center justify-content-center flex-column result-style">
+        <div>
+            <span>Preview:</span>
+            <div id="preview">
+
+            </div>
+        </div>
         <p id="result"></p>
         <button type="button" class="btn btn-secondary" id="copyButton" style="display: none;" onclick="copyToClipboard()">Copy</button>
     </div>

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ function generateTimestamp() {
     else {
         throw new Error("A required element was not found.");
     }
+    showPreview();
 }
 function copyToClipboard() {
     let resultElement = document.getElementById("result");
@@ -77,5 +78,70 @@ function showToast(message) {
     }
     else {
         throw new Error("Toast element not found.");
+    }
+}
+function formatDateForPreview(dateString, format) {
+    let date = new Date(dateString);
+    let options;
+    switch (format) {
+        case FormatOption.Default:
+            options = { dateStyle: 'medium', timeStyle: 'short' };
+            break;
+        case FormatOption.ShortTime:
+            options = { hour: '2-digit', minute: '2-digit' };
+            break;
+        case FormatOption.LongTime:
+            options = { hour: '2-digit', minute: '2-digit', second: '2-digit' };
+            break;
+        case FormatOption.ShortDate:
+            options = { year: 'numeric', month: 'numeric', day: 'numeric' };
+            break;
+        case FormatOption.LongDate:
+            options = { year: 'numeric', month: 'long', day: 'numeric' };
+            break;
+        case FormatOption.ShortDateTime:
+            options = { dateStyle: 'short', timeStyle: 'short' };
+            break;
+        case FormatOption.LongDateTime:
+            options = { dateStyle: 'full', timeStyle: 'long' };
+            break;
+        case FormatOption.RelativeTime:
+            let now = new Date();
+            let diffInSeconds = Math.floor((date.getTime() - now.getTime()) / 1000);
+            let formatter = new Intl.RelativeTimeFormat('de', { numeric: 'auto' });
+            let relativeTime;
+            if (Math.abs(diffInSeconds) < 60) {
+                relativeTime = formatter.format(diffInSeconds, 'seconds');
+            }
+            else if (Math.abs(diffInSeconds) < 3600) {
+                relativeTime = formatter.format(Math.floor(diffInSeconds / 60), 'minutes');
+            }
+            else if (Math.abs(diffInSeconds) < 86400) {
+                relativeTime = formatter.format(Math.floor(diffInSeconds / 3600), 'hours');
+            }
+            else {
+                relativeTime = formatter.format(Math.floor(diffInSeconds / 86400), 'days');
+            }
+            return relativeTime;
+        default:
+            throw new Error("Ungültige Formatoption.");
+    }
+    return new Intl.DateTimeFormat('de-DE', options).format(date);
+}
+function showPreview() {
+    let dateInputElement = document.getElementById("dateInput");
+    let formatOptionElement = document.getElementById("formatOption");
+    let previewElement = document.getElementById("preview");
+    if (dateInputElement && formatOptionElement && previewElement) {
+        let dateInput = dateInputElement.value;
+        if (!dateInput) {
+            dateInput = new Date().toISOString();
+        }
+        let formatOption = formatOptionElement.value;
+        let formattedDate = formatDateForPreview(dateInput, formatOption);
+        previewElement.innerText = formattedDate;
+    }
+    else {
+        showToast("Ein erforderliches Element wurde nicht gefunden.");
     }
 }

--- a/index.ts
+++ b/index.ts
@@ -54,6 +54,7 @@ function generateTimestamp(): void {
     } else {
         throw new Error("A required element was not found.");
     }
+    showPreview();
 }
 
 function copyToClipboard(): void {
@@ -80,5 +81,72 @@ function showToast(message: string): void {
         }, 3000);
     } else {
         throw new Error("Toast element not found.");
+    }
+}
+
+function formatDateForPreview(dateString: string, format: FormatOption): string {
+    let date = new Date(dateString);
+    let options: Intl.DateTimeFormatOptions;
+
+    switch (format) {
+        case FormatOption.Default:
+            options = { dateStyle: 'medium', timeStyle: 'short' };
+            break;
+        case FormatOption.ShortTime:
+            options = { hour: '2-digit', minute: '2-digit' };
+            break;
+        case FormatOption.LongTime:
+            options = { hour: '2-digit', minute: '2-digit', second: '2-digit' };
+            break;
+        case FormatOption.ShortDate:
+            options = { year: 'numeric', month: 'numeric', day: 'numeric' };
+            break;
+        case FormatOption.LongDate:
+            options = { year: 'numeric', month: 'long', day: 'numeric' };
+            break;
+        case FormatOption.ShortDateTime:
+            options = { dateStyle: 'short', timeStyle: 'short' };
+            break;
+        case FormatOption.LongDateTime:
+            options = { dateStyle: 'full', timeStyle: 'long' };
+            break;
+        case FormatOption.RelativeTime:
+            let now = new Date();
+            let diffInSeconds = Math.floor((date.getTime() - now.getTime()) / 1000);
+            let formatter = new Intl.RelativeTimeFormat('de', { numeric: 'auto' });
+            let relativeTime;
+
+            if (Math.abs(diffInSeconds) < 60) {
+                relativeTime = formatter.format(diffInSeconds, 'seconds');
+            } else if (Math.abs(diffInSeconds) < 3600) {
+                relativeTime = formatter.format(Math.floor(diffInSeconds / 60), 'minutes');
+            } else if (Math.abs(diffInSeconds) < 86400) {
+                relativeTime = formatter.format(Math.floor(diffInSeconds / 3600), 'hours');
+            } else {
+                relativeTime = formatter.format(Math.floor(diffInSeconds / 86400), 'days');
+            }
+            return relativeTime;
+        default:
+            throw new Error("Ungültige Formatoption.");
+    }
+
+    return new Intl.DateTimeFormat('de-DE', options).format(date);
+}
+
+function showPreview(): void {
+    let dateInputElement = document.getElementById("dateInput") as HTMLInputElement;
+    let formatOptionElement = document.getElementById("formatOption") as HTMLSelectElement;
+    let previewElement = document.getElementById("preview");
+
+    if (dateInputElement && formatOptionElement && previewElement) {
+        let dateInput = dateInputElement.value;
+        if (!dateInput) {
+            dateInput = new Date().toISOString();
+        }
+        let formatOption = formatOptionElement.value as FormatOption;
+        let formattedDate = formatDateForPreview(dateInput, formatOption);
+        previewElement.innerText = formattedDate;
+    } else {
+        showToast("Ein erforderliches Element wurde nicht gefunden.");
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature that adds a preview of the formatted timestamp in the Discord Timestamp Formatter. The changes include updates to both the HTML and JavaScript/TypeScript files to support this new functionality.

### UI Enhancements:
* Added a new `div` element to display the preview of the formatted timestamp in `index.html`.

### JavaScript Changes:
* Updated `generateTimestamp` function to call `showPreview` in `index.js`.
* Added `showPreview` function to generate and display the formatted date based on user input in `index.js`.
* Added `formatDateForPreview` function to handle various date formatting options in `index.js`.

### TypeScript Changes:
* Updated `generateTimestamp` function to call `showPreview` in `index.ts`.
* Added `showPreview` function to generate and display the formatted date based on user input in `index.ts`.
* Added `formatDateForPreview` function to handle various date formatting options in `index.ts`.