### PR TITLE
Fix slide-out animation class lingering

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ function showPreview() {
 function showOptions() {
     let element = document.getElementById("options");
     if (element) {
+        element.classList.remove("slide-out-left");
         element.classList.add("show-options");
         element.classList.add("slide-in-left");
         element.classList.remove("d-none");

--- a/index.ts
+++ b/index.ts
@@ -154,6 +154,7 @@ function showPreview(): void {
 function showOptions() {
     let element = document.getElementById("options");
     if (element) {
+        element.classList.remove("slide-out-left");
         element.classList.add("show-options");
         element.classList.add("slide-in-left");
         element.classList.remove("d-none");


### PR DESCRIPTION
## Summary
- prevent `slide-out-left` from conflicting with `slide-in-left`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684479105d508322b5674d3af8d85a8c